### PR TITLE
Upgrade cucumber

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     cukesalad (0.8.0)
       aruba (= 0.4.3)
-      cucumber (= 1.0.2)
+      cucumber (= 1.0.6)
       rspec (>= 2.5.0)
 
 GEM
@@ -21,12 +21,12 @@ GEM
     builder (3.0.0)
     childprocess (0.2.2)
       ffi (~> 1.0.6)
-    cucumber (1.0.2)
+    cucumber (1.0.6)
       builder (>= 2.1.2)
       diff-lcs (>= 1.1.2)
-      gherkin (~> 2.4.5)
+      gherkin (~> 2.4.18)
       json (>= 1.4.6)
-      term-ansicolor (>= 1.0.5)
+      term-ansicolor (>= 1.0.6)
     diff-lcs (1.1.3)
     ffi (1.0.9)
     ffi (1.0.9-java)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -38,7 +38,7 @@ GEM
     json (1.4.6-java)
     mime-types (1.16)
     rack (1.3.2)
-    rake (0.8.7)
+    rake (0.9.2)
     rdiscount (1.6.8)
     relish (0.3.0)
       archive-tar-minitar (~> 0.5.2)
@@ -63,5 +63,5 @@ PLATFORMS
 DEPENDENCIES
   bundler (~> 1.0.0)
   cukesalad!
-  rake (~> 0.8.7)
+  rake (~> 0.9.2)
   relish (= 0.3.0)

--- a/cukesalad.gemspec
+++ b/cukesalad.gemspec
@@ -30,6 +30,6 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency "aruba",    "0.4.3"
 
   s.add_development_dependency "bundler", "~> 1.0.0"
-  s.add_development_dependency "rake", "~> 0.8.7"
+  s.add_development_dependency "rake", "~> 0.9.2"
   s.add_development_dependency "relish", "= 0.3.0"
 end

--- a/cukesalad.gemspec
+++ b/cukesalad.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |s|
   s.default_executable = "cukesalad"
   s.require_paths      = ["lib"]
 
-  s.add_runtime_dependency "cucumber", "1.0.2" # Version 1.0.4 experiences following error: 'Illformed requirement ["#<Syck::DefaultKey:0x000001034764a0> 0.8.4"]'
+  s.add_runtime_dependency "cucumber", "1.0.6"
   s.add_runtime_dependency "rspec",    ">=2.5.0"
   s.add_runtime_dependency "aruba",    "0.4.3"
 


### PR DESCRIPTION
If you are having trouble with the latest version of cucumber it's because you need to update rubygems and remove any gems installed on the older version of Rubygems.

If you're using rvm:

$ rvm gemset clear

$ gem update --system

$ rvm @global gem install bundler

$ bundle

more info: http://stackoverflow.com/questions/7379385/invalid-gemspec-in-and-illformed-requirement-whenever-i-create-a-new-project
